### PR TITLE
Create header-bar on settings dialog for CSD

### DIFF
--- a/src/pref_dialog.c
+++ b/src/pref_dialog.c
@@ -199,18 +199,12 @@ static void pref_dialog_init(PrefDialog *dlg)
 	gtk_grid_attach(GTK_GRID(dlg->grid), dlg->mpvopt_entry, 0, 11, 2, 1);
 }
 
-GtkWidget *pref_dialog_new(GtkWindow *parent)
+static void pref_dialog_show(PrefDialog *dlg, gint csd)
 {
-	PrefDialog *dlg = g_object_new(pref_dialog_get_type(), NULL);
-
-	gtk_window_set_transient_for(GTK_WINDOW(dlg), parent);
-	gtk_widget_show_all(GTK_WIDGET(dlg));
-
-	if (main_window_get_csd_enabled(parent) == 1) {
-		/* Create header-bar components with old method */
+	if (csd == 1)
+	{
 		GtkWidget *headerbar = gtk_header_bar_new();
 
-		/* cancel button on left-most */
 		GtkWidget *cancel_button = gtk_button_new_with_label
 							(_("_Cancel"));
 		gtk_button_set_use_underline(GTK_BUTTON(cancel_button), TRUE);
@@ -221,11 +215,10 @@ GtkWidget *pref_dialog_new(GtkWindow *parent)
 		 * gtk_container_remove anyway on gtk-3.16.
 		 */
 		gtk_widget_reparent(cancel_button, headerbar);
-		gtk_container_child_set (GTK_CONTAINER(headerbar),
+		gtk_container_child_set(GTK_CONTAINER(headerbar),
 					 cancel_button,
 					"pack-type", GTK_PACK_START, NULL);
 
-		/* save button on right-most */
 		GtkWidget *save_button = gtk_button_new_with_label
 							(_("_Save"));
 		gtk_button_set_use_underline(GTK_BUTTON(save_button), TRUE);
@@ -233,28 +226,43 @@ GtkWidget *pref_dialog_new(GtkWindow *parent)
 					     save_button,
 					     GTK_RESPONSE_ACCEPT);
 		gtk_widget_reparent(save_button, headerbar);
-		gtk_container_child_set (GTK_CONTAINER(headerbar),
-					 save_button,
-					 "pack-type", GTK_PACK_END, NULL);
+		gtk_container_child_set(GTK_CONTAINER(headerbar),
+					save_button,
+					"pack-type", GTK_PACK_END, NULL);
 
-		/* header-bar title */
 		gtk_header_bar_set_title(GTK_HEADER_BAR(headerbar),
 							_("Preferences"));
 		gtk_window_set_titlebar(GTK_WINDOW(dlg), headerbar);
 
 		gtk_widget_show_all(headerbar);
+
+		gtk_widget_show_all(GTK_WIDGET(dlg));
 	} else {
-		/* create traditional title-bar and action-area	*/
 		gtk_window_set_title(GTK_WINDOW(dlg), _("Preferences"));
-		/* left-most cancel button is for Gnome-HIG */
-		gtk_dialog_add_buttons(	GTK_DIALOG(dlg),
-					_("_Cancel"),
-					GTK_RESPONSE_REJECT,
-					_("_Save"),
-					GTK_RESPONSE_ACCEPT,
-					NULL );
+		gtk_dialog_add_buttons(GTK_DIALOG(dlg),
+				       _("_Cancel"),
+				       GTK_RESPONSE_REJECT,
+				       _("_Save"),
+				       GTK_RESPONSE_ACCEPT,
+				       NULL );
+
+		gtk_widget_show_all(GTK_WIDGET(dlg));
 	}
-   
+}
+
+GtkWidget *pref_dialog_new(GtkWindow *parent)
+{
+	PrefDialog *dlg = g_object_new(pref_dialog_get_type(), NULL);
+
+	gtk_window_set_transient_for(GTK_WINDOW(dlg), parent);
+
+	if (main_window_get_csd_enabled(parent) == 1)
+	{
+		pref_dialog_show(dlg, 1);
+	} else{
+		pref_dialog_show(dlg, 0);
+	}
+
 	return GTK_WIDGET(dlg);
 }
 

--- a/src/pref_dialog.c
+++ b/src/pref_dialog.c
@@ -20,6 +20,7 @@
 #include <glib/gi18n.h>
 
 #include "pref_dialog.h"
+#include "main_window.h"
 
 static void response_handler(	GtkDialog *dialog,
 				gint response_id,
@@ -149,15 +150,7 @@ static void pref_dialog_init(PrefDialog *dlg)
 	gtk_widget_set_size_request(dlg->mpvconf_button, 100, -1);
 	gtk_widget_set_size_request(dlg->mpvinput_button, 100, -1);
 
-	gtk_dialog_add_buttons(	GTK_DIALOG(dlg),
-				_("_Save"),
-				GTK_RESPONSE_ACCEPT,
-				_("_Cancel"),
-				GTK_RESPONSE_REJECT,
-				NULL );
-
 	gtk_window_set_modal(GTK_WINDOW(dlg), 1);
-	gtk_window_set_title(GTK_WINDOW(dlg), _("Preferences"));
 
 	gtk_window_set_geometry_hints(	GTK_WINDOW(dlg),
 					GTK_WIDGET(dlg),
@@ -213,6 +206,55 @@ GtkWidget *pref_dialog_new(GtkWindow *parent)
 	gtk_window_set_transient_for(GTK_WINDOW(dlg), parent);
 	gtk_widget_show_all(GTK_WIDGET(dlg));
 
+	if (main_window_get_csd_enabled(parent) == 1) {
+		/* Create header-bar components with old method */
+		GtkWidget *headerbar = gtk_header_bar_new();
+
+		/* cancel button on left-most */
+		GtkWidget *cancel_button = gtk_button_new_with_label
+							(_("_Cancel"));
+		gtk_button_set_use_underline(GTK_BUTTON(cancel_button), TRUE);
+		gtk_dialog_add_action_widget(GTK_DIALOG(dlg),
+					     cancel_button,
+					     GTK_RESPONSE_REJECT);
+		/* FIXME - gtk_widget_reparent should be replaced to
+		 * gtk_container_remove anyway on gtk-3.16.
+		 */
+		gtk_widget_reparent(cancel_button, headerbar);
+		gtk_container_child_set (GTK_CONTAINER(headerbar),
+					 cancel_button,
+					"pack-type", GTK_PACK_START, NULL);
+
+		/* save button on right-most */
+		GtkWidget *save_button = gtk_button_new_with_label
+							(_("_Save"));
+		gtk_button_set_use_underline(GTK_BUTTON(save_button), TRUE);
+		gtk_dialog_add_action_widget(GTK_DIALOG(dlg),
+					     save_button,
+					     GTK_RESPONSE_ACCEPT);
+		gtk_widget_reparent(save_button, headerbar);
+		gtk_container_child_set (GTK_CONTAINER(headerbar),
+					 save_button,
+					 "pack-type", GTK_PACK_END, NULL);
+
+		/* header-bar title */
+		gtk_header_bar_set_title(GTK_HEADER_BAR(headerbar),
+							_("Preferences"));
+		gtk_window_set_titlebar(GTK_WINDOW(dlg), headerbar);
+
+		gtk_widget_show_all(headerbar);
+	} else {
+		/* create traditional title-bar and action-area	*/
+		gtk_window_set_title(GTK_WINDOW(dlg), _("Preferences"));
+		/* left-most cancel button is for Gnome-HIG */
+		gtk_dialog_add_buttons(	GTK_DIALOG(dlg),
+					_("_Cancel"),
+					GTK_RESPONSE_REJECT,
+					_("_Save"),
+					GTK_RESPONSE_ACCEPT,
+					NULL );
+	}
+   
 	return GTK_WIDGET(dlg);
 }
 

--- a/src/pref_dialog.c
+++ b/src/pref_dialog.c
@@ -199,9 +199,9 @@ static void pref_dialog_init(PrefDialog *dlg)
 	gtk_grid_attach(GTK_GRID(dlg->grid), dlg->mpvopt_entry, 0, 11, 2, 1);
 }
 
-static void pref_dialog_show(PrefDialog *dlg, gint csd)
+static void pref_dialog_show(PrefDialog *dlg, gboolean csd)
 {
-	if (csd == 1)
+	if (csd)
 	{
 		GtkWidget *headerbar = gtk_header_bar_new();
 
@@ -256,11 +256,12 @@ GtkWidget *pref_dialog_new(GtkWindow *parent)
 
 	gtk_window_set_transient_for(GTK_WINDOW(dlg), parent);
 
-	if (main_window_get_csd_enabled(parent) == 1)
+	/* FIXME - parent has 'struct GtkWindow' type */
+	if (main_window_get_csd_enabled(parent))
 	{
-		pref_dialog_show(dlg, 1);
-	} else{
-		pref_dialog_show(dlg, 0);
+		pref_dialog_show(dlg, TRUE);
+	} else {
+		pref_dialog_show(dlg, FALSE);
 	}
 
 	return GTK_WIDGET(dlg);

--- a/src/pref_dialog.c
+++ b/src/pref_dialog.c
@@ -256,8 +256,7 @@ GtkWidget *pref_dialog_new(GtkWindow *parent)
 
 	gtk_window_set_transient_for(GTK_WINDOW(dlg), parent);
 
-	/* FIXME - parent has 'struct GtkWindow' type */
-	if (main_window_get_csd_enabled(parent))
+	if (main_window_get_csd_enabled(MAIN_WINDOW(parent)))
 	{
 		pref_dialog_show(dlg, TRUE);
 	} else {

--- a/src/pref_dialog.h
+++ b/src/pref_dialog.h
@@ -53,6 +53,9 @@ struct PrefDialog
 	GtkWidget *mpvconf_enable_check;
 	GtkWidget *mpvconf_button;
 	GtkWidget *mpvopt_entry;
+	GtkWidget *headerbar;
+	GtkWidget *cancel_button;
+	GtkWidget *save_button;
 };
 
 struct PrefDialogClass


### PR DESCRIPTION
@gnome-mpv Hi developers,

Now I'm creating header-bar for settings dialog, and the 1st implementation seems to work fine on my Ubuntu Vivid and Gtk-3.16.3. I already had to pick some "old-style" functions to put header-bar buttons into title-bar. Those codes were based on out upstream Gnome git's `gtkdialog.c`. If we could rebase `pref-dialog.c` with `gtk_dialog_add_buttons ()`, this code could get more simpler though.

And one more thing. From the teste of *Gnome Human Interface Guideline*, the "Cancel" button must be placed on the left-most side (if LTR locales were applied), and I agreed this fact. So I've swapped button order in traditional case (means "without CSD", the place of Action-Area in GtkDialog) as well.

Finally hope this could help your hard works. :smiley: 

Regards.