### PR TITLE
Multi-monitor fullscreen fix

### DIFF
--- a/src/main_window.c
+++ b/src/main_window.c
@@ -569,11 +569,17 @@ void main_window_toggle_fullscreen(MainWindow *wnd)
 	else
 	{
 		GdkScreen *screen;
+		GdkRectangle monitor_geometry;
 		gint width;
 		gint height;
+		gint monitor;
 
 		screen = gtk_window_get_screen(GTK_WINDOW(wnd));
-		width = gdk_screen_width()/2;
+		monitor = gdk_screen_get_monitor_at_window(	screen,
+				gtk_widget_get_window(GTK_WIDGET(wnd)) );
+		gdk_screen_get_monitor_geometry(screen, monitor, &monitor_geometry);
+
+		width = monitor_geometry.width/2;
 
 		g_object_ref(wnd->control_box);
 		gtk_container_remove(main_box, wnd->control_box);
@@ -611,8 +617,8 @@ void main_window_toggle_fullscreen(MainWindow *wnd)
 					height );
 
 		gtk_window_move(	GTK_WINDOW(wnd->fs_control),
-					(gdk_screen_width()/2)-(width/2),
-					gdk_screen_height()-height );
+					monitor_geometry.x+width/2,
+					monitor_geometry.y+monitor_geometry.height-height );
 
 		gtk_window_set_transient_for(	GTK_WINDOW(wnd->fs_control),
 						GTK_WINDOW(wnd) );

--- a/src/main_window.c
+++ b/src/main_window.c
@@ -61,14 +61,22 @@ static gboolean focus_in_handler(	GtkWidget *widget,
 	{
 		gint width;
 		gint height;
+		gint monitor;
+		GdkRectangle monitor_geometry;
+		GdkScreen *screen;
+
+		screen = gtk_window_get_screen(GTK_WINDOW(wnd));
+		monitor = gdk_screen_get_monitor_at_window(	screen,
+				gtk_widget_get_window(GTK_WIDGET(wnd)) );
+		gdk_screen_get_monitor_geometry(screen, monitor, &monitor_geometry);
 
 		gtk_window_get_size(	GTK_WINDOW(wnd->fs_control),
 					&width,
 					&height );
 
 		gtk_window_move(	GTK_WINDOW(wnd->fs_control),
-					(gdk_screen_width()/2)-(width/2),
-					gdk_screen_height()-height );
+					monitor_geometry.x+(width/2),
+					monitor_geometry.y+monitor_geometry.height-height );
 
 		gtk_widget_show_all(wnd->fs_control);
 	}


### PR DESCRIPTION
This pull request hopefully fixes issue #45.

I have tested the fullscreen mode on:
- two monitors side-by-side
- one monitor on top of another
- a single monitor

It works on my setup, `Manjaro Linux` with `GTK 3.16.6`.

As I am new to GTK, I do not know yet when `focus_in_handler()` would be called. Commit 1b80e98 alone did the trick for me... I still edited `focus_in_handler()` to match `main_window_toggle_fullscreen()`, just in case.