### PR TITLE
Fix various warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,9 +23,41 @@ GLIB_GSETTINGS
 
 AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug], [turn on debugging]))
 
-AS_IF(	[test "x$enable_debug" = "xyes"],
-	[CFLAGS="-Wall -pedantic -g -fsanitize=address"],
-	[CFLAGS="-O2 -fomit-frame-pointer -Wno-deprecated-declarations"] )
+AS_IF([test "x$enable_debug" = "xyes"], [
+	AX_APPEND_COMPILE_FLAGS([-O0 -g -fsanitize=address])
+], [
+	AX_APPEND_COMPILE_FLAGS([-O2])
+])
+
+AX_APPEND_COMPILE_FLAGS([ \
+	-std=gnu99 \
+	-funsigned-char \
+	-fstack-protector-strong \
+	-fPIE \
+	-fPIC \
+	-Wall \
+	-Wextra \
+dnl	-Wconversion
+	-Wno-sign-compare \ dnl FIXME
+	-Winline \
+	-Wno-padded \
+	-Wno-unused-parameter \
+	-Wstrict-prototypes \
+	-Wmissing-prototypes \
+	-Werror=implicit-function-declaration \
+	-Werror=pointer-arith \
+	-Werror=init-self \
+	-Werror=format-security \
+	-Werror=format=2 \
+	-Werror=missing-include-dirs \
+	-Werror=date-time \
+])
+
+AX_APPEND_LINK_FLAGS([ \
+	-pie \
+	-Wl,-z,relro \
+	-Wl,-z,now \
+])
 
 # Checks for programs.
 AC_PROG_CC

--- a/src/actionctl.c
+++ b/src/actionctl.c
@@ -420,18 +420,18 @@ static void about_handler(	GSimpleAction *action,
 void actionctl_map_actions(gmpv_handle *ctx)
 {
 	const GActionEntry entries[]
-		= {	{"open", open_handler, NULL, NULL, NULL},
-			{"quit", quit_handler, NULL, NULL, NULL},
-			{"about", about_handler, NULL, NULL, NULL},
-			{"pref", pref_handler, NULL, NULL, NULL},
-			{"openloc", open_loc_handler, NULL, NULL, NULL},
-			{"playlist_toggle", playlist_toggle_handler, NULL, NULL, NULL},
-			{"playlist_save", playlist_save_handler, NULL, NULL, NULL},
-			{"loadsub", load_sub_handler, NULL, NULL, NULL},
-			{"fullscreen", fullscreen_handler, NULL, NULL, NULL},
-			{"normalsize", normal_size_handler, NULL, NULL, NULL},
-			{"doublesize", double_size_handler, NULL, NULL, NULL},
-			{"halfsize", half_size_handler, NULL, NULL, NULL} };
+		= {	{.name = "open",            .activate = open_handler},
+			{.name = "quit",            .activate = quit_handler},
+			{.name = "about",           .activate = about_handler},
+			{.name = "pref",            .activate = pref_handler},
+			{.name = "openloc",         .activate = open_loc_handler},
+			{.name = "playlist_toggle", .activate = playlist_toggle_handler},
+			{.name = "playlist_save",   .activate = playlist_save_handler},
+			{.name = "loadsub",         .activate = load_sub_handler},
+			{.name = "fullscreen",      .activate = fullscreen_handler},
+			{.name = "normalsize",      .activate = normal_size_handler},
+			{.name = "doublesize",      .activate = double_size_handler},
+			{.name = "halfsize",        .activate = half_size_handler} };
 
 	g_action_map_add_action_entries(	G_ACTION_MAP(ctx->app),
 						entries,

--- a/src/control_box.c
+++ b/src/control_box.c
@@ -206,7 +206,8 @@ GType control_box_get_type(void)
 				NULL,
 				sizeof(ControlBox),
 				0,
-				(GInstanceInitFunc)control_box_init };
+				(GInstanceInitFunc)control_box_init,
+				NULL };
 
 		box_type = g_type_register_static(	GTK_TYPE_BOX,
 							"ControlBox",

--- a/src/keybind.c
+++ b/src/keybind.c
@@ -267,8 +267,8 @@ GSList *keybind_parse_config(const gchar *config_path, gboolean* propexp)
 
 gchar **keybind_get_command(	gmpv_handle *ctx,
 				gboolean mouse,
-				gint modifier,
-				gint keyval )
+				guint modifier,
+				guint keyval )
 {
 	GSList *iter = ctx->keybind_list;
 	keybind *kb = iter->data;

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -27,8 +27,8 @@
 struct keybind
 {
 	gboolean mouse;
-	gint modifier;
-	gint keyval;
+	guint modifier;
+	guint keyval;
 	gchar **command;
 };
 
@@ -38,8 +38,8 @@ keybind *keybind_parse_config_line(const gchar *line, gboolean *propexp);
 GSList *keybind_parse_config(const gchar *config_path, gboolean *propexp);
 gchar **keybind_get_command(	gmpv_handle *ctx,
 				gboolean mouse,
-				gint modifier,
-				gint keyval );
+				guint modifier,
+				guint keyval );
 GSList *keybind_parse_config_with_defaults(	const gchar *config_path,
 						gboolean *propexp );
 

--- a/src/main.c
+++ b/src/main.c
@@ -376,6 +376,8 @@ static void connect_signals(gmpv_handle *ctx)
 
 static void setup_accelerators(gmpv_handle *ctx)
 {
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS // Deprecated in Gtk 3.14, TODO: gtk_application_set_accels_for_action
+
 	gtk_application_add_accelerator(	ctx->app,
 						"<Control>o",
 						"app.open",
@@ -425,6 +427,7 @@ static void setup_accelerators(gmpv_handle *ctx)
 						"F11" ,
 						"app.fullscreen",
 						NULL );
+G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 static GMenu *build_app_menu()
@@ -535,7 +538,7 @@ static void app_startup_handler(GApplication *app, gpointer data)
 	control_box_set_chapter_enabled
 		(CONTROL_BOX(ctx->gui->control_box), FALSE);
 
-	ctx->vid_area_wid = gdk_x11_window_get_xid
+	ctx->vid_area_wid = (gint64)gdk_x11_window_get_xid
 				(gtk_widget_get_window(ctx->gui->vid_area));
 
 	main_window_load_state(ctx->gui);

--- a/src/main_window.c
+++ b/src/main_window.c
@@ -46,8 +46,8 @@ static gboolean configure_handler(	GtkWidget *widget,
 					gpointer data );
 static gboolean hide_cursor(gpointer data);
 static gboolean finalize_load_state(gpointer data);
-static GMenu *menu_btn_build_menu();
-static GMenu *open_btn_build_menu();
+static GMenu *menu_btn_build_menu(void);
+static GMenu *open_btn_build_menu(void);
 static void main_window_class_init(MainWindow *wnd);
 static void main_window_init(MainWindow *wnd);
 
@@ -531,7 +531,8 @@ GType main_window_get_type()
 				NULL,
 				sizeof(MainWindow),
 				0,
-				(GInstanceInitFunc)main_window_init };
+				(GInstanceInitFunc)main_window_init,
+				NULL };
 
 		wnd_type = g_type_register_static
 				(	GTK_TYPE_APPLICATION_WINDOW,

--- a/src/media_keys/media_keys.h
+++ b/src/media_keys/media_keys.h
@@ -27,8 +27,8 @@ typedef struct media_keys media_keys;
 struct media_keys
 {
 	gmpv_handle *gmpv_ctx;
-	guint g_signal_sig_id;
-	guint shutdown_sig_id;
+	gulong g_signal_sig_id;
+	gulong shutdown_sig_id;
 	GDBusProxy *proxy;
 	GDBusConnection *session_bus_conn;
 };

--- a/src/mpris/mpris.h
+++ b/src/mpris/mpris.h
@@ -31,9 +31,9 @@ struct mpris
 	guint name_id;
 	guint base_reg_id;
 	guint player_reg_id;
-	guint shutdown_sig_id;
-	guint *base_sig_id_list;
-	guint *player_sig_id_list;
+	gulong shutdown_sig_id;
+	gulong *base_sig_id_list;
+	gulong *player_sig_id_list;
 	gdouble pending_seek;
 	GHashTable *base_prop_table;
 	GHashTable *player_prop_table;

--- a/src/mpris/mpris_base.c
+++ b/src/mpris/mpris_base.c
@@ -213,7 +213,7 @@ void mpris_base_register(mpris *inst)
 						(GDestroyNotify)
 						g_variant_unref );
 
-	inst->base_sig_id_list = g_malloc(2*sizeof(guint));
+	inst->base_sig_id_list = g_malloc(2*sizeof(gulong));
 
 	inst->base_sig_id_list[0]
 		= g_signal_connect(	inst->gmpv_ctx->gui,
@@ -242,7 +242,7 @@ void mpris_base_register(mpris *inst)
 
 void mpris_base_unregister(mpris *inst)
 {
-	guint *current_sig_id = inst->base_sig_id_list;
+	gulong *current_sig_id = inst->base_sig_id_list;
 
 	while(current_sig_id && *current_sig_id > 0)
 	{

--- a/src/mpris/mpris_player.c
+++ b/src/mpris/mpris_player.c
@@ -667,7 +667,7 @@ void mpris_player_register(mpris *inst)
 						(GDestroyNotify)
 						g_variant_unref );
 
-	inst->player_sig_id_list = g_malloc(4*sizeof(guint));
+	inst->player_sig_id_list = g_malloc(4*sizeof(gulong));
 
 	inst->player_sig_id_list[0]
 		= g_signal_connect(	inst->gmpv_ctx->gui,
@@ -708,7 +708,7 @@ void mpris_player_register(mpris *inst)
 
 void mpris_player_unregister(mpris *inst)
 {
-	guint *current_sig_id = inst->player_sig_id_list;
+	gulong *current_sig_id = inst->player_sig_id_list;
 
 	while(current_sig_id && *current_sig_id > 0)
 	{

--- a/src/open_loc_dialog.c
+++ b/src/open_loc_dialog.c
@@ -139,7 +139,8 @@ GType open_loc_dialog_get_type()
 				NULL,
 				sizeof(OpenLocDialog),
 				0,
-				(GInstanceInitFunc)open_loc_dialog_init };
+				(GInstanceInitFunc)open_loc_dialog_init,
+				NULL };
 
 		dlg_type = g_type_register_static(	GTK_TYPE_DIALOG,
 							"OpenLocDialog",

--- a/src/playlist_widget.c
+++ b/src/playlist_widget.c
@@ -79,7 +79,8 @@ GType playlist_widget_get_type()
 				NULL,
 				sizeof(PlaylistWidget),
 				0,
-				(GInstanceInitFunc)playlist_widget_init };
+				(GInstanceInitFunc)playlist_widget_init,
+				NULL };
 
 		wgt_type = g_type_register_static
 				(	GTK_TYPE_SCROLLED_WINDOW,

--- a/src/pref_dialog.c
+++ b/src/pref_dialog.c
@@ -70,6 +70,15 @@ static gboolean key_press_handler(	GtkWidget *widget,
 	return FALSE;
 }
 
+static inline void set_margin_start(GtkWidget *widget, gint margin)
+{
+#if GTK_CHECK_VERSION(3, 12, 0)
+	gtk_widget_set_margin_start(widget, margin);
+#else
+	gtk_widget_set_margin_left(widget, margin);
+#endif
+}
+
 static void pref_dialog_init(PrefDialog *dlg)
 {
 	GdkGeometry geom;
@@ -152,14 +161,16 @@ static void pref_dialog_init(PrefDialog *dlg)
 	gtk_widget_set_hexpand(dlg->mpvinput_button, TRUE);
 	gtk_widget_set_hexpand(dlg->mpvopt_entry, TRUE);
 
-	gtk_widget_set_margin_left(mpvconf_label, 10);
-	gtk_widget_set_margin_left(mpvinput_label, 10);
-	gtk_widget_set_margin_left(mpvopt_label, 10);
-	gtk_widget_set_margin_left(dlg->csd_enable_check, 10);
-	gtk_widget_set_margin_left(dlg->dark_theme_enable_check, 10);
-	gtk_widget_set_margin_left(dlg->mpvconf_enable_check, 10);
-	gtk_widget_set_margin_left(dlg->mpvinput_enable_check, 10);
-	gtk_widget_set_margin_left(dlg->mpvopt_entry, 10);
+
+
+	set_margin_start(mpvconf_label, 10);
+	set_margin_start(mpvinput_label, 10);
+	set_margin_start(mpvopt_label, 10);
+	set_margin_start(dlg->csd_enable_check, 10);
+	set_margin_start(dlg->dark_theme_enable_check, 10);
+	set_margin_start(dlg->mpvconf_enable_check, 10);
+	set_margin_start(dlg->mpvinput_enable_check, 10);
+	set_margin_start(dlg->mpvopt_entry, 10);
 
 	gtk_widget_set_size_request(dlg->mpvconf_button, 100, -1);
 	gtk_widget_set_size_request(dlg->mpvinput_button, 100, -1);
@@ -299,7 +310,8 @@ GType pref_dialog_get_type()
 				NULL,
 				sizeof(PrefDialog),
 				0,
-				(GInstanceInitFunc)pref_dialog_init };
+				(GInstanceInitFunc)pref_dialog_init,
+				NULL };
 
 		dlg_type = g_type_register_static(	GTK_TYPE_DIALOG,
 							"PrefDialog",


### PR DESCRIPTION
There are still a lot of warnings hidden under -Wconversion and -Wsign-compare and there are a few deprecated uses of Gtk that I'll get to later, but this cleans up most things.

Question though do you have an issue targeting the latest GLib? You seemed to do a lot of GObject things by hand which can easily be replaced by a simple macro.

Oh and also would you mind if I added a prefix to your widgets to follow standard GObject style, as in GMWindow?