### PR TITLE
Handle OpenGL on various Gdk Backends

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_PROG_CC
 AC_PROG_CC_STDC
 
 # Checks for libraries.
-PKG_CHECK_MODULES(DEPS, [gtk+-3.0 >= 3.16 glib-2.0 >= 2.40 mpv >= 1.16 gl])
+PKG_CHECK_MODULES(DEPS, [gtk+-3.0 >= 3.16 glib-2.0 >= 2.40 mpv >= 1.16 epoxy])
 AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_40], [Dont warn using older APIs])
 AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_40], [Prevents using newer APIs])
 

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -20,7 +20,7 @@
 #ifndef KEYBIND_H
 #define KEYBIND_H
 
-#include <gdk/gdkx.h>
+#include <gdk/gdk.h>
 
 #include "common.h"
 


### PR DESCRIPTION
Gdk can be built with or without wayland/x11/etc so we should handle that. Also when using the wayland backend make use of egl not glx.