### PR TITLE
[Proposal] Use default mouse cursor as supplied by theme.

### DIFF
--- a/src/main_window.c
+++ b/src/main_window.c
@@ -102,8 +102,8 @@ static gboolean motion_notify_handler(GtkWidget *widget, GdkEventMotion *event)
 	MainWindow *wnd = MAIN_WINDOW(widget);
 	GdkCursor *cursor;
 
-	cursor = gdk_cursor_new_for_display(	gdk_display_get_default(),
-						GDK_ARROW );
+	cursor = gdk_cursor_new_from_name(	gdk_display_get_default(),
+						"default" );
 
 	gdk_window_set_cursor
 		(gtk_widget_get_window(GTK_WIDGET(wnd->vid_area)), cursor);


### PR DESCRIPTION
Using GDK_ARROW breaks cursor theme. This is not noticeable with Adwaita because the `arrow` cursor is identical to `default`.  When using a different cursor theme or environment lacking (an identical) `arrow`, the cursor as shown [here](https://developer.gnome.org/gdk3/stable/gdk3-Cursors.html#GdkCursorType)  is used.

 ![arrow](https://developer.gnome.org/gdk3/stable/arrow.png)

This can be slightly disorienting and is a minor discomfort.