### PR TITLE
Fix make distcheck

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_INIT(	[gnome-mpv],
 		[http://github.com/gnome-mpv/gnome-mpv] )
 
 AC_CONFIG_SRCDIR([src/main.c])
+AC_CONFIG_MACRO_DIR([m4])
 AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([1.12 tar-pax dist-xz no-dist-gzip subdir-objects foreign -Wall -Wno-portability])
 AM_SILENT_RULES([yes])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -20,6 +20,8 @@ icon_DATA = gnome-mpv.svg
 symicondir = $(datadir)/icons/hicolor/symbolic/apps
 symicon_DATA = gnome-mpv-symbolic.svg
 
-EXTRA_DIST =	$(gsettings_SCHEMAS) $(appstream_in_files) $(desktop_in_files) \
-		gnome-mpv.desktop gnome-mpv.svg gnome-mpv-symbolic.svg \
+EXTRA_DIST =	$(appstream_in_files) $(desktop_in_files) \
+		gnome-mpv.svg gnome-mpv-symbolic.svg \
 		mpris_gdbus.xml org.gnome-mpv.gschema.xml.in
+
+DISTCLEANFILES = $(appstream_XML) $(gsettings_SCHEMAS) $(desktop_DATA)


### PR DESCRIPTION
Also for future releases please use `make dist` and upload the tarball for github releases, this removes some dependencies on external projects not actually required for building.