### PR TITLE
Update media keys timestamp when window is focused

### DIFF
--- a/src/media_keys/gmpv_media_keys.h
+++ b/src/media_keys/gmpv_media_keys.h
@@ -29,6 +29,7 @@ struct gmpv_media_keys
 	GmpvApplication *gmpv_ctx;
 	gulong g_signal_sig_id;
 	gulong shutdown_sig_id;
+	gulong focus_sig_id;
 	GDBusProxy *proxy;
 	GDBusConnection *session_bus_conn;
 };


### PR DESCRIPTION
As per the documentation this allows multiple applications to grab media keys but the last one to be  focused will get them.