### PR TITLE
Change Fedora package URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ capabilities.
 - Arch Linux (Git): https://aur.archlinux.org/packages/gnome-mpv-git
 - Debian testing: https://packages.debian.org/testing/gnome-mpv
 - Debian unstable: https://packages.debian.org/sid/gnome-mpv
-- Fedora (russianfedora): http://koji.russianfedora.pro/koji/packageinfo?packageID=155
+- Fedora (rpmfusion): https://admin.rpmfusion.org/pkgdb/package/free/gnome-mpv/
 - Frugalware: http://www4.frugalware.org/pub/linux/distributions/frugalware/frugalware-current/source/xapps-extra/gnome-mpv/
 - OpenSUSE: https://build.opensuse.org/package/show/home:mermoldy:multimedia/gnome-mpv
 - Gentoo: http://gpo.zugaina.org/media-video/gnome-mpv


### PR DESCRIPTION
Now Fedora gnome-mpv package moved from russianfedora to rpmfusion.