### PR TITLE
Include meson files in dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,15 +2,6 @@ AUTOMAKE_OPTIONS = foreign
 
 SUBDIRS = src data po
 
-DISTCLEANFILES =	intltool-extract \
-			intltool-merge \
-			intltool-update \
-			po/.intltool-merge-cache
-
-INTLTOOL_FILES =	intltool-extract.in \
-			intltool-merge.in \
-			intltool-update.in
-
 EXTRA_DIST = README.md AUTHORS
 
 UPDATE_DESKTOP = update-desktop-database -q || :

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 
 SUBDIRS = src data po
 
-EXTRA_DIST = README.md AUTHORS
+EXTRA_DIST = README.md AUTHORS meson.build meson_post_install.py po/meson.build
 
 UPDATE_DESKTOP = update-desktop-database -q || :
 UPDATE_ICON = gtk-update-icon-cache -q $(datadir)/icons/hicolor/ || :

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ capabilities.
 - autoconf-archive<sup>[[1]](#note1)</sup> (build)
 - automake >= 1.12<sup>[[1]](#note1)</sup> (build)
 - python2<sup>[[1]](#note1)</sup> (build)
-- intltool >= 0.40.6 (build)
 - pkg-config (build)
 - gcc (build)
 - glib >= 2.44

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST =	$(appstream_in_files) $(desktop_in_files) \
 		gnome-mpv.svg gnome-mpv-symbolic.svg \
 		org.gnome-mpv.gschema.xml \
 		io.github.GnomeMpv.gschema.xml \
-		gmpv_mpris_gdbus.xml gmpv_marshal.lst
+		gmpv_mpris_gdbus.xml gmpv_marshal.lst \
+		meson.build
 
 DISTCLEANFILES = $(appstream_XML) $(desktop_DATA)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,3 +76,4 @@ gnome_mpv_CFLAGS =	$(DEPS_CFLAGS) \
 gnome_mpv_LDADD = $(DEPS_LIBS)
 
 CLEANFILES = $(mpris_generated) $(marshal_generated) $(authors_generated)
+EXTRA_DIST = meson.build generate_authors.py


### PR DESCRIPTION
While supporting both for a while ship the meson files in the dist for packagers to use.