### PR TITLE
Use absolute bindir in dbus service

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -32,7 +32,7 @@ install_data('gnome-mpv-symbolic.svg',
 )
 
 service_conf = configuration_data()
-service_conf.set('bindir', get_option('bindir'))
+service_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
 
 configure_file(
   input: 'io.github.GnomeMpv.service.in',


### PR DESCRIPTION
Before, the script generated the following line:
```Exec=bin/gnome-mpv --gapplication-service```
Which caused `dbus-daemon` to fail to find the binary.

Now it will prepend the install prefix like so:
```Exec=/usr/bin/gnome-mpv --gapplication-service```

~However, even with the fixed path, attempting to launch the application yields the following error:
```Failed to activate service 'io.github.GnomeMpv': timed out```
I haven't managed to track down the cause yet.~