### PR TITLE
Menu entry to shuffle the playlist

### DIFF
--- a/src/gmpv_controller_actions.c
+++ b/src/gmpv_controller_actions.c
@@ -65,6 +65,9 @@ static void toggle_playlist_handler(	GSimpleAction *action,
 static void save_playlist_handler(	GSimpleAction *action,
 					GVariant *param,
 					gpointer data );
+static void shuffle_playlist_handler(	GSimpleAction *action,
+					GVariant *param,
+					gpointer data );
 static void remove_selected_playlist_item_handler(	GSimpleAction *action,
 							GVariant *param,
 							gpointer data );
@@ -278,6 +281,13 @@ static void save_playlist_handler(	GSimpleAction *action,
 	gmpv_view_show_save_playlist_dialog(gmpv_controller_get_view(data));
 }
 
+static void shuffle_playlist_handler(	GSimpleAction *action,
+					GVariant *param,
+					gpointer data )
+{
+	gmpv_model_shuffle_playlist(gmpv_controller_get_model(data));
+}
+
 static void remove_selected_playlist_item_handler(	GSimpleAction *action,
 							GVariant *param,
 							gpointer data )
@@ -425,6 +435,8 @@ void gmpv_controller_action_register_actions(GmpvController *controller)
 			.activate = toggle_playlist_handler},
 			{.name = "save-playlist",
 			.activate = save_playlist_handler},
+			{.name = "shuffle-playlist",
+			.activate = shuffle_playlist_handler},
 			{.name = "remove-selected-playlist-item",
 			.activate = remove_selected_playlist_item_handler},
 			{.name = "set-audio-track",

--- a/src/gmpv_model.c
+++ b/src/gmpv_model.c
@@ -941,6 +941,13 @@ void gmpv_model_previous_playlist_entry(GmpvModel *model)
 	gmpv_mpv_command(model->mpv, cmd);
 }
 
+void gmpv_model_shuffle_playlist(GmpvModel *model)
+{
+	const gchar *cmd[] = {"osd-msg", "playlist-shuffle", NULL};
+
+	gmpv_mpv_command(model->mpv, cmd);
+}
+
 void gmpv_model_seek(GmpvModel *model, gdouble value)
 {
 	gmpv_mpv_set_property(model->mpv, "time-pos", MPV_FORMAT_DOUBLE, &value);

--- a/src/gmpv_model.h
+++ b/src/gmpv_model.h
@@ -48,6 +48,7 @@ void gmpv_model_next_chapter(GmpvModel *model);
 void gmpv_model_previous_chapter(GmpvModel *model);
 void gmpv_model_next_playlist_entry(GmpvModel *model);
 void gmpv_model_previous_playlist_entry(GmpvModel *model);
+void gmpv_model_shuffle_playlist(GmpvModel *model);
 void gmpv_model_seek(GmpvModel *model, gdouble value);
 void gmpv_model_seek_offset(GmpvModel *model, gdouble offset);
 void gmpv_model_load_audio_track(GmpvModel *model, const gchar *filename);

--- a/src/gmpv_playlist_widget.c
+++ b/src/gmpv_playlist_widget.c
@@ -523,6 +523,7 @@ static gboolean mouse_press_handler(	GtkWidget *widget,
 		GMenuItem *add_menu_item;
 		GMenuItem *add_loc_menu_item;
 		GMenuItem *loop_menu_item;
+		GMenuItem *shuffle_menu_item;
 		GtkWidget *ctx_menu;
 
 		menu = g_menu_new();
@@ -535,10 +536,12 @@ static gboolean mouse_press_handler(	GtkWidget *widget,
 				(	_("Add _Location…"),
 					"win.show-open-location-dialog(true)" );
 		loop_menu_item = g_menu_item_new(_("Loop"), "win.toggle-loop");
+		shuffle_menu_item = g_menu_item_new(_("Shuffle"), "win.shuffle-playlist");
 
 		g_menu_append_item(menu, add_menu_item);
 		g_menu_append_item(menu, add_loc_menu_item);
 		g_menu_append_item(menu, loop_menu_item);
+		g_menu_append_item(menu, shuffle_menu_item);
 		g_menu_freeze(menu);
 
 		ctx_menu = gtk_menu_new_from_model(G_MENU_MODEL(menu));


### PR DESCRIPTION
This pull request resolves #178. It adds a menu entry in the right-click menu of the playlist widget to  shuffle the playlist.