### PR TITLE
Add basic release information to appdata

### DIFF
--- a/data/io.github.GnomeMpv.appdata.xml.in
+++ b/data/io.github.GnomeMpv.appdata.xml.in
@@ -23,6 +23,9 @@
    <li>MPRIS2 D-Bus interface</li>
   </ul>
  </description>
+ <releases>
+  <release date="2017-06-12" version="0.12"/>
+ </releases>
  <screenshots>
   <screenshot type="default">
    <image>http://gnome-mpv.github.io/images/screenshot-0.png</image>


### PR DESCRIPTION
This is the only method for tools like gnome-software to reliably get version information.

In the future full release notes should be here.