### PR TITLE
meson: Install appstream metadata to non-deprecated location

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -10,7 +10,7 @@ appdata = i18n.merge_file(
   output: 'io.github.GnomeMpv.appdata.xml',
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 desktop = i18n.merge_file(


### PR DESCRIPTION
/usr/share/metainfo/ has been the preferred location for
appstream metadata since appstream 0.9.4 two years ago.

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location

The autotools build already installs there with recent version of appstream-glib.